### PR TITLE
Made it so that previous events are displayed in correct order

### DIFF
--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -30,43 +30,6 @@ export const useEvents = () => {
             try {
                 setLoading(true);
 
-                while (hasPreviousPage) {
-                    const url = startCursor
-                        ? `https://guild.host/api/next/torc-dev/events/past?first=50&after=${startCursor}`
-                        : 'https://guild.host/api/next/torc-dev/events/past';
-
-                    const response = await fetch(url);
-                    if (!response.ok) {
-                        throw new Error(`HTTP error! status: ${response.status}`);
-                    }
-
-                    const data: ApiResponse = await response.json();
-
-                    if (data?.events?.edges) {
-                        data.events.edges.forEach(({node: event}) => {
-                            const date = format(parseISO(event.startAt), 'yyyy-MM-dd');
-
-                            const formattedEvent: Event = {
-                                id: event.id,
-                                title: event.name,
-                                description: event.description || '',
-                                date: format(parseISO(event.startAt), 'MMMM d, yyyy'),
-                                time: event.startAt,
-                                thumbnail: event.uploadedSocialCard?.url || 'https://images.unsplash.com/photo-1501281668745-f7f57925c3b4?auto=format&fit=crop&q=80',
-                                link: `https://guild.host/events/${event.prettyUrl}`,
-                                images: event.uploadedSocialCard?.url ? [event.uploadedSocialCard.url] : []
-                            };
-
-                            if (!allFormattedEvents[date]) {
-                                allFormattedEvents[date] = [];
-                            }
-                            allFormattedEvents[date].push(formattedEvent);
-                        });
-                    }
-                    hasPreviousPage = data.events.pageInfo.hasPreviousPage;
-                    startCursor = data.events.pageInfo.startCursor;
-                }
-
                 while (hasNextPage) {
                     const url = endCursor
                         ? `https://guild.host/api/next/torc-dev/events/upcoming?first=50&after=${endCursor}`
@@ -101,10 +64,49 @@ export const useEvents = () => {
                         });
                     }
                     hasPreviousPage = data.events.pageInfo.hasPreviousPage;
-                    startCursor = data.events.pageInfo.startCursor;
-
                     hasNextPage = data.events.pageInfo.hasNextPage;
                     endCursor = data.events.pageInfo.endCursor;
+                    startCursor = data.events.pageInfo.startCursor;
+                }
+                while (hasPreviousPage) {
+                    const url = startCursor
+                        ? `https://guild.host/api/next/torc-dev/events/past?after=${startCursor}?before=${endCursor}`
+                        : 'https://guild.host/api/next/torc-dev/events/past';
+
+                    const response = await fetch(url);
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+
+                    const data: ApiResponse = await response.json();
+
+                    if (data?.events?.edges) {
+                        data.events.edges.forEach(({node: event}) => {
+                            const date = format(parseISO(event.startAt), 'yyyy-MM-dd');
+
+                            const formattedEvent: Event = {
+                                id: event.id,
+                                title: event.name,
+                                description: event.description || '',
+                                date: format(parseISO(event.startAt), 'MMMM d, yyyy'),
+                                time: event.startAt,
+                                thumbnail: event.uploadedSocialCard?.url || 'https://images.unsplash.com/photo-1501281668745-f7f57925c3b4?auto=format&fit=crop&q=80',
+                                link: `https://guild.host/events/${event.prettyUrl}`,
+                                images: event.uploadedSocialCard?.url ? [event.uploadedSocialCard.url] : []
+                            };
+
+                            if (!allFormattedEvents[date]) {
+                                allFormattedEvents[date] = [];
+                            }
+                            // forcibly putting the new formatted event at the beginning of the array
+                            // so that we don't have a UI bug where events display out of order
+                            allFormattedEvents[date] = [formattedEvent, ...allFormattedEvents[date]]
+                        });
+                    }
+                    hasPreviousPage = data.events.pageInfo.hasPreviousPage;
+                    hasNextPage = data.events.pageInfo.hasNextPage;
+                    endCursor = data.events.pageInfo.endCursor;
+                    startCursor = data.events.pageInfo.startCursor;
                 }
                 setEvents(allFormattedEvents);
             } catch (error) {

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -29,45 +29,6 @@ export const useEvents = () => {
 
             try {
                 setLoading(true);
-
-                while (hasNextPage) {
-                    const url = endCursor
-                        ? `https://guild.host/api/next/torc-dev/events/upcoming?first=50&after=${endCursor}`
-                        : 'https://guild.host/api/next/torc-dev/events/upcoming';
-
-                    const response = await fetch(url);
-                    if (!response.ok) {
-                        throw new Error(`HTTP error! status: ${response.status}`);
-                    }
-
-                    const data: ApiResponse = await response.json();
-
-                    if (data?.events?.edges) {
-                        data.events.edges.forEach(({node: event}) => {
-                            const date = format(parseISO(event.startAt), 'yyyy-MM-dd');
-
-                            const formattedEvent: Event = {
-                                id: event.id,
-                                title: event.name,
-                                description: event.description || '',
-                                date: format(parseISO(event.startAt), 'MMMM d, yyyy'),
-                                time: event.startAt,
-                                thumbnail: event.uploadedSocialCard?.url || 'https://images.unsplash.com/photo-1501281668745-f7f57925c3b4?auto=format&fit=crop&q=80',
-                                link: `https://guild.host/events/${event.prettyUrl}`,
-                                images: event.uploadedSocialCard?.url ? [event.uploadedSocialCard.url] : []
-                            };
-
-                            if (!allFormattedEvents[date]) {
-                                allFormattedEvents[date] = [];
-                            }
-                            allFormattedEvents[date].push(formattedEvent);
-                        });
-                    }
-                    hasPreviousPage = data.events.pageInfo.hasPreviousPage;
-                    hasNextPage = data.events.pageInfo.hasNextPage;
-                    endCursor = data.events.pageInfo.endCursor;
-                    startCursor = data.events.pageInfo.startCursor;
-                }
                 while (hasPreviousPage) {
                     const url = startCursor
                         ? `https://guild.host/api/next/torc-dev/events/past?after=${startCursor}?before=${endCursor}`
@@ -101,6 +62,44 @@ export const useEvents = () => {
                             // forcibly putting the new formatted event at the beginning of the array
                             // so that we don't have a UI bug where events display out of order
                             allFormattedEvents[date] = [formattedEvent, ...allFormattedEvents[date]]
+                        });
+                    }
+                    hasPreviousPage = data.events.pageInfo.hasPreviousPage;
+                    hasNextPage = data.events.pageInfo.hasNextPage;
+                    endCursor = data.events.pageInfo.endCursor;
+                    startCursor = data.events.pageInfo.startCursor;
+                }
+                while (hasNextPage) {
+                    const url = endCursor
+                        ? `https://guild.host/api/next/torc-dev/events/upcoming?first=50&after=${endCursor}`
+                        : 'https://guild.host/api/next/torc-dev/events/upcoming';
+
+                    const response = await fetch(url);
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+
+                    const data: ApiResponse = await response.json();
+
+                    if (data?.events?.edges) {
+                        data.events.edges.forEach(({node: event}) => {
+                            const date = format(parseISO(event.startAt), 'yyyy-MM-dd');
+
+                            const formattedEvent: Event = {
+                                id: event.id,
+                                title: event.name,
+                                description: event.description || '',
+                                date: format(parseISO(event.startAt), 'MMMM d, yyyy'),
+                                time: event.startAt,
+                                thumbnail: event.uploadedSocialCard?.url || 'https://images.unsplash.com/photo-1501281668745-f7f57925c3b4?auto=format&fit=crop&q=80',
+                                link: `https://guild.host/events/${event.prettyUrl}`,
+                                images: event.uploadedSocialCard?.url ? [event.uploadedSocialCard.url] : []
+                            };
+
+                            if (!allFormattedEvents[date]) {
+                                allFormattedEvents[date] = [];
+                            }
+                            allFormattedEvents[date].push(formattedEvent);
                         });
                     }
                     hasPreviousPage = data.events.pageInfo.hasPreviousPage;


### PR DESCRIPTION
In my last PR, I accidentally made it so that events before the current date would display in reverse order (e.g. 5PM event would display before 12PM event). The screenshots showing correct order for previous events and upcoming events should show that this issue is fixed :)

<img width="1064" alt="Screenshot 2025-02-17 at 7 18 45 PM" src="https://github.com/user-attachments/assets/e8b03c63-e710-49cb-9468-0abba14a0adb" />
<img width="1064" alt="Screenshot 2025-02-17 at 7 18 50 PM" src="https://github.com/user-attachments/assets/a154dd32-1d8e-4bc0-8d1f-038c937227df" />
