### PR TITLE
Fix Torc Calendar not displaying upcoming events

### DIFF
--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -31,7 +31,7 @@ export const useEvents = () => {
                 setLoading(true);
                 while (hasPreviousPage) {
                     const url = startCursor
-                        ? `https://guild.host/api/next/torc-dev/events/past?after=${startCursor}?before=${endCursor}`
+                        ? `https://guild.host/api/next/torc-dev/events/past?after=${startCursor}&before=${endCursor}`
                         : 'https://guild.host/api/next/torc-dev/events/past';
 
                     const response = await fetch(url);
@@ -65,15 +65,12 @@ export const useEvents = () => {
                         });
                     }
                     hasPreviousPage = data.events.pageInfo.hasPreviousPage;
-                    hasNextPage = data.events.pageInfo.hasNextPage;
-                    endCursor = data.events.pageInfo.endCursor;
                     startCursor = data.events.pageInfo.startCursor;
                 }
                 while (hasNextPage) {
                     const url = endCursor
                         ? `https://guild.host/api/next/torc-dev/events/upcoming?first=50&after=${endCursor}`
                         : 'https://guild.host/api/next/torc-dev/events/upcoming';
-
                     const response = await fetch(url);
                     if (!response.ok) {
                         throw new Error(`HTTP error! status: ${response.status}`);
@@ -102,10 +99,8 @@ export const useEvents = () => {
                             allFormattedEvents[date].push(formattedEvent);
                         });
                     }
-                    hasPreviousPage = data.events.pageInfo.hasPreviousPage;
                     hasNextPage = data.events.pageInfo.hasNextPage;
                     endCursor = data.events.pageInfo.endCursor;
-                    startCursor = data.events.pageInfo.startCursor;
                 }
                 setEvents(allFormattedEvents);
             } catch (error) {


### PR DESCRIPTION
Removing certain statements that unnecessarily updated `startCursor`, `endCursor`, `hasPreviousPage`, and `hasNextPage`, as well as a slight correction to one of the URLs, seems ot have resolved the issue of upcoming events not loading 

<img width="1095" alt="Screenshot 2025-02-18 at 1 20 44 PM" src="https://github.com/user-attachments/assets/329dc713-203c-48d2-bb4f-50675c94ab03" />
<img width="1095" alt="Screenshot 2025-02-18 at 1 20 53 PM" src="https://github.com/user-attachments/assets/b45c8254-ff4f-4a50-b04d-8291a964a144" />
<img width="1095" alt="Screenshot 2025-02-18 at 1 20 59 PM" src="https://github.com/user-attachments/assets/b6a7ace2-6910-46ca-86a4-5229506f359d" />
